### PR TITLE
Implement toroidal layers for gpt-oss

### DIFF
--- a/gpt_oss/generate.py
+++ b/gpt_oss/generate.py
@@ -4,6 +4,7 @@
 # torchrun --nproc-per-node=4 -m gpt_oss.generate -p "why did the chicken cross the road?" model/
 
 import argparse
+import os
 
 from gpt_oss.tokenizer import get_tokenizer
 
@@ -14,6 +15,11 @@ def main(args):
             from gpt_oss.torch.utils import init_distributed
             from gpt_oss.torch.model import TokenGenerator as TorchGenerator
             device = init_distributed()
+            # Environment variables pass config via checkpoint config.json; for quick toggles, set env
+            if args.toroidal_linear:
+                os.environ["GPT_OSS_TOROIDAL_LINEAR"] = "1"
+            if args.circular_causal:
+                os.environ["GPT_OSS_CIRCULAR_CAUSAL"] = "1"
             generator = TorchGenerator(args.checkpoint, device=device)
         case "triton":
             from gpt_oss.torch.utils import init_distributed
@@ -76,6 +82,16 @@ if __name__ == "__main__":
         default="torch",
         choices=["triton", "torch", "vllm"],
         help="Inference backend",
+    )
+    parser.add_argument(
+        "--toroidal-linear",
+        action="store_true",
+        help="Enable toroidal linear wrapping (torch backend only)",
+    )
+    parser.add_argument(
+        "--circular-causal",
+        action="store_true",
+        help="Enable circular causal attention mask (torch backend only)",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
Introduce runtime toroidal linear layers and circular causal attention masks to eliminate edge effects.

This PR adds "seamless optimization" features, allowing linear layers to operate on a toroidal (wrap-around) grid and attention to consider sequences as circular. All transformations are performed at runtime via padding and slicing, ensuring no changes to the model's stored weights or checkpoint format. This addresses the user's request to achieve "unbound, with no edge effects" behavior without altering persistent weights.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc31dfef-1a6d-45af-ae5b-df04581e4a25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dc31dfef-1a6d-45af-ae5b-df04581e4a25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

